### PR TITLE
Fixed typographical error, changed availabe to available in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ with::
 
 Note that we gave the sample a name (``github`` in this case).
 
-To list all availabe samples use::
+To list all available samples use::
 
     $ python test_samples.py -l
 


### PR DESCRIPTION
scrapy, I've corrected a typographical error in the documentation of the [loginform](https://github.com/scrapy/loginform) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.