### PR TITLE
Correct bug when html.SelectElement appears inside form.inputs

### DIFF
--- a/loginform.py
+++ b/loginform.py
@@ -63,6 +63,8 @@ def _pick_fields(form):
 def submit_value(form):
     """Returns the value for the submit input, if any"""
     for x in form.inputs:
+        if not isinstance(x, html.InputElement):
+            continue
         if x.type == "submit" and x.name:
             return [(x.name, x.value)]
     else:


### PR DESCRIPTION
`inputs` inside a `form` can be `InputElement` or `SelectElement`. The latter ones do not have a `type` field, causing an `AttributeError`. For exampling when trying to login inside this page: `http://webconnect.groupnews.com.au/login.aspx`:

```
  File "/home/nenu/.virtualenvs/development/local/lib/python2.7/site-packages/loginform.py", line 66, in submit_value
    if x.type == "submit" and x.name:
AttributeError: 'SelectElement' object has no attribute 'type'
```